### PR TITLE
Use .hg/branch to determin branch name for the prompt.

### DIFF
--- a/env_functions.sh
+++ b/env_functions.sh
@@ -29,10 +29,12 @@ hg_prompt() {
   local repo
   repo=$(prompt::_find_repo .hg) || return 0
   cd "$repo" || return # so Mercurial doesn't have to do the same find we just did
-  local branch num_heads heads
-  # `hg branch` may be slow for large repos, read it from .hg
-  { branch=$(<.hg/branch) || printf default; } 2>/dev/null
-  num_heads=$(hg heads --template '{rev} ' 2> /dev/null | wc -w) || return 0
+
+  local branch="default"
+  # `hg branch` may be slow for large repos, read it from .hg/
+  [[ -f .hg/branch ]] branch=$(<.hg/branch)
+
+  local num_heads=$(hg heads --template '{rev} ' 2> /dev/null | wc -w) || return 0
   if (( num_heads > 1 )); then
     heads='*'
   fi

--- a/env_functions.sh
+++ b/env_functions.sh
@@ -29,12 +29,10 @@ hg_prompt() {
   local repo
   repo=$(prompt::_find_repo .hg) || return 0
   cd "$repo" || return # so Mercurial doesn't have to do the same find we just did
-
-  local branch="default"
+  local branch=default num_heads heads
   # `hg branch` may be slow for large repos, read it from .hg/
-  [[ -f .hg/branch ]] branch=$(<.hg/branch)
-
-  local num_heads=$(hg heads --template '{rev} ' 2> /dev/null | wc -w) || return 0
+  [[ -f .hg/branch ]] && branch=$(<.hg/branch)
+  num_heads=$(hg heads --template '{rev} ' 2> /dev/null | wc -w) || return 0
   if (( num_heads > 1 )); then
     heads='*'
   fi

--- a/env_functions.sh
+++ b/env_functions.sh
@@ -30,7 +30,8 @@ hg_prompt() {
   repo=$(prompt::_find_repo .hg) || return 0
   cd "$repo" || return # so Mercurial doesn't have to do the same find we just did
   local branch num_heads heads
-  branch=$(hg branch 2> /dev/null) || return 0
+  # `hg branch` may be slow for large repos, read it from .hg
+  { branch=$(<.hg/branch) || printf default; } 2>/dev/null
   num_heads=$(hg heads --template '{rev} ' 2> /dev/null | wc -w) || return 0
   if (( num_heads > 1 )); then
     heads='*'


### PR DESCRIPTION
Note that `hg stats` was removed from the invocation to get timings below:

Before
:; time for ((i=0;i<100;i++)); do hg branch >/dev/null; done

real    0m34.073s
user    0m26.268s
sys     0m14.923s

After
:; time for ((i=0;i<100;i++)); do cat .hg/branch >/dev/null; done

real    0m0.468s
user    0m0.216s
sys     0m0.220s