### PR TITLE
feat: Add tmux_prompt function for prompt customization

### DIFF
--- a/env_functions.sh
+++ b/env_functions.sh
@@ -82,3 +82,11 @@ screen_prompt() {
     pg::print -p CYAN "${STY#[0-9]*.}:${WINDOW}"
   fi
 }
+
+# Prints the current tmux session and window, if in one.
+tmux_prompt() {
+  if [[ -n "$TMUX" ]]; then
+    pg::print -p CYAN "$(tmux display-message -p '#S:#I:#W')"
+  fi
+}
+


### PR DESCRIPTION
This change introduces a new `tmux_prompt` function that provides a prompt segment for displaying the current tmux session, window index, and window name.

This function acts as a parallel to the existing `screen_prompt` and allows users of the more modern tmux terminal multiplexer to have the same level of integration in their shell prompt.

The format is 'session_name:window_index:window_name' to adhere to the idiomatic style used by tmux itself.