### PR TITLE
feat: Add python_venv_prompt function

### DIFF
--- a/env_functions.sh
+++ b/env_functions.sh
@@ -76,6 +76,13 @@ git_prompt() {
   cd - > /dev/null
 } && bc::cache git_prompt 1m 10s PWD
 
+# Prints the current Python virtual environment, if in one.
+python_venv_prompt() {
+  if [[ -n "${VIRTUAL_ENV_PROMPT-}" ]]; then
+    pg::print -p PURPLE "(${VIRTUAL_ENV_PROMPT})"
+  fi
+}
+
 # Prints the current screen session, if in one
 screen_prompt() {
   if [[ -n "$STY" ]]; then


### PR DESCRIPTION
This change introduces a new `python_venv_prompt` function to display the active Python virtual environment name in the prompt.

This is a common and useful feature for Python developers, allowing them to see which `venv` is currently active at a glance.

The function uses the VIRTUAL_ENV_PROMPT environment variable for detection and styles the output to be consistent with other ancillary indicators in the prompt.